### PR TITLE
Input/Output loop

### DIFF
--- a/Toki_Pona.pro
+++ b/Toki_Pona.pro
@@ -116,3 +116,8 @@
 % This file contains the DCG and Prolog rules for a user friendly input.
 :- ['toki-pona-io-rules.pro'].
 
+% Start the io loop if we are not called for compiling
+:- current_prolog_flag(os_argv,Argv),               % get all args for prolog
+   \+ member('--stand_alone=true',Argv) -> io_loop  % start if not compiling
+   ; true.                                          % just avoid warning.
+

--- a/make.sh
+++ b/make.sh
@@ -15,7 +15,10 @@ echo " "
 #
 rm -f *.out
 echo "make $PROLOG_MAIN_FILE.out"
-swipl -nodebug -g true -O -q --stand_alone=true -o  "$PROLOG_MAIN_FILE.out" -c "$PROLOG_MAIN_FILE.pro" > /dev/null 2> /dev/null
+
+# '-t io_loop' is needed to start the loop in the stand alone version
+swipl -nodebug -g true -t io_loop -O -q --stand_alone=true -o  "$PROLOG_MAIN_FILE.out" -c "$PROLOG_MAIN_FILE.pro" > /dev/null 2> /dev/null
+
 if [ $? != 0  ]; then
         echo "ERROR"
         exit 1

--- a/toki-pona-io-rules.pro
+++ b/toki-pona-io-rules.pro
@@ -8,6 +8,15 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % For a user friendly input:
 
+% Read lines and analyze until we read an empty line
+io_loop :- repeat, check_grammar, halt.
+
+check_grammar :-
+    read_line(CL),                                 % read a line
+    ( CL = [] -> true                              % exit loop on empty line
+      ; wordlist(WL,CL,[]), !, sentence(P,WL,[]),  % analyze
+      write(P), nl, fail).                         % print results and loop
+
 % check_grammar(P)          :- read_line(CL), wordlist(WL,CL,[]), !, sentence(P,WL,[]).   % Read a line from the user, put it in a list of words and check it with "sentence".
 check_grammar(P)          :- read_line(CL), wordlist(WL,CL,[]), !, paragraph(P,WL,[]).   % Read a line from the user, put it in a list of words and check it with "sentence".
 


### PR DESCRIPTION
Enter io loop upon start, so the user does not have to type
"check_grammar(P)." for every single line.

This needed a check, if compilation was going on. We must not run the io loop when compiling otherwise the compilation would not terminate. I did this by checking for the '--stand-alone' flag. If the flag has been used to call swipl, the loop is not started.
