### PR TITLE
Updated test procedures

### DIFF
--- a/toki-pona-test-files.pro
+++ b/toki-pona-test-files.pro
@@ -32,8 +32,8 @@ print_line(CL) :- atom_codes(L,CL), write(L), nl.
 % check a line that should be correct
 check_right_line :-
     read_file_line(CL), wordlist(WL,CL,[]), !,
-    (sentence(_,WL,[]) -> true
-    ; write('failed: '), print_line(CL)).
+    (paragraph(_,WL,[]) -> true
+    ; flag(testFailed,_,1), write('Error - wrongly fails: '), print_line(CL)).
 
 % check file with correct lines.
 check_right :-
@@ -42,7 +42,9 @@ check_right :-
 % check a line that should be wrong
 check_wrong_line :-
     read_file_line(CL), wordlist(WL,CL,[]), !,
-    (sentence(_,WL,[]) -> write('succeeded: '), print_line(CL)
+    (paragraph(_,WL,[]) -> flag(testFailed,_,1),
+     write('Error - wrongly passes: '), print_line(CL),
+     foreach(paragraph(P,WL,[]),(write('-> '), write(P), nl))
      ; true).
 
 % check file with correct lines.
@@ -81,9 +83,13 @@ check_read(File,Pred) :-
 % This file contains the DCG and Prolog rules for a user friendly input.
 :- ['toki-pona-io-rules.pro'].
 
+% reset error flag. This is not really needed as any 'flag' is initialized
+% to 0 by Prolog. But so we know what we do
+:- flag(testFailed,_,0).
+
 % Run the tests
 :- check_read('toki-pona-sentences-right.txt',check_right).
-% :- check_read('toki-pona-sentences-wrong.txt',check_wrong).
+:- check_read('toki-pona-sentences-wrong.txt',check_wrong).
 
-% exit
-:- halt.
+% exit, returning the result of the tests
+:- flag(testFailed,Value,0), halt(Value).


### PR DESCRIPTION
use 'paragraph' instead of 'sentence' for testing
report solutions found for sentences that should fail
set exit code to 1 when errors are found

It now prints all solutions found for test lines that should fail, but don't. If you don't like it, I can remove it very easily.

Since it should return an error code when there are problems found, I'd expect travis to fail on this PR.
With the current test files I get this result:

<pre>Checking file toki-pona-sentences-right.txt
Error - wrongly fails: mama mi o ! 
Error - wrongly fails: jan sona pona o ! 
Error - wrongly fails: sewi mi o ! 
Error - wrongly fails: mi wile lukin e ma e suno e ni e sina e ona . 
Error - wrongly fails: mi wile lukin e ma e suno e ni e sina e ona li pona e ijo . 
Error - wrongly fails: mi moku li ma li pona li pipi li pakala li kili li lukin . 
Error - wrongly fails: ma suli Wawawa li ike .  
Error - wrongly fails: mi toki kepeken ,  toki pona .  
Error - wrongly fails: mi kin tawa kin .  
Error - wrongly fails: mi kin olin e sina .  
Error - wrongly fails: mi kin lukin e ona .  
Error - wrongly fails: mi kin wile tawa tomo mi .  
Error - wrongly fails: mi kin olin e sina .  
Error - wrongly fails: akesi Kondo
Error - wrongly fails: name
Error - wrongly fails: sina wile jo e mani seme ,  tan jan ni ?  
Error - wrongly fails: jan lili pi ma Nu Silen li sona lili e toki Moli . 
Error - wrongly fails: kalama musi pi jan Lolina Mikenitu li pona tawa mi . 
Checking file toki-pona-sentences-wrong.txt
Error - wrongly passes: jan pi nanpa wan li lon . 
-> s(dec(sim(np(sub((noun(jan),sep(pi),noun(nanpa),card(numeral(wan)))),sep(li)),vp(verb_int(lon)))),sep(.))
-> s(dec(sim(np(sub((noun(jan),sep(pi),noun(nanpa),card(numeral(wan)))),sep(li)),vp(be,obj_be(adjective(lon))))),sep(.))
-> s(dec(sim(np(sub((noun(jan),sep(pi),noun(nanpa),card(numeral(wan)))),sep(li)),vp(be,obj_be(noun(lon))))),sep(.))
Error - wrongly passes: meli mi pi nanpa wan li nasa . 
-> s(dec(sim(np(sub(((noun(meli),pronoun(mi)),sep(pi),noun(nanpa),card(numeral(wan)))),sep(li)),vp(verb_tra(nasa)))),sep(.))
-> s(dec(sim(np(sub(((noun(meli),pronoun(mi)),sep(pi),noun(nanpa),card(numeral(wan)))),sep(li)),vp(be,obj_be(adjective(nasa))))),sep(.))
-> s(dec(sim(np(sub(((noun(meli),pronoun(mi)),sep(pi),noun(nanpa),card(numeral(wan)))),sep(li)),vp(be,obj_be(noun(nasa))))),sep(.))
Error - wrongly passes: mi moku e moku mute mute mi .  
-> s(dec(sim(np(sub(pronoun(mi))),vp(verb_tra(moku),obj_d(sep(e), (noun(moku),card((adjective(mute),adjective(mute))),pronoun(mi)))))),sep(.))
-> s(dec(sim(np(sub(pronoun(mi))),vp(verb_tra(moku),obj_d(sep(e), (noun(moku),adjective(mute),card(numeral(mute)),pronoun(mi)))))),sep(.))
-> s(dec(sim(np(sub(pronoun(mi))),vp(verb_tra(moku),obj_d(sep(e), (noun(moku),adjective(mute),card(adjective(mute)),pronoun(mi)))))),sep(.))
Error - wrongly passes: mi tan seme ? 
-> s(int(what_i_object(np(sub(pronoun(mi))),vp(verb_int(tan),obj_i(question_word(seme))))),sep(?))
-> s(int(what_is_object(np(sub(pronoun(mi))),vp(be,obj_be(noun(tan),question_word(seme))))),sep(?))
Error - wrongly passes: ni li jan lili ona pi nanpa tu . 
-> s(dec(sim(np(sub(pronoun(ni)),sep(li)),vp(be,obj_be(((noun(jan),adjective(lili),pronoun(ona)),sep(pi),noun(nanpa),card(numeral(tu))))))),sep(.))
-> s(dec(sim(np(sub(pronoun(ni)),sep(li)),vp(be,obj_be(((noun(jan),card(adjective(lili)),pronoun(ona)),sep(pi),noun(nanpa),card(numeral(tu))))))),sep(.))
Error - wrongly passes: ni li jan nanpa mute ale mute mute luka tu wan . 
-> s(dec(sim(np(sub(pronoun(ni)),sep(li)),vp(be,obj_be(((adjective(jan),adjective(nanpa),adjective(mute)),card((numeral(ale), (numeral(mute),numeral(mute)),numeral(luka),numeral(tu),numeral(wan)))))))),sep(.))
-> s(dec(sim(np(sub(pronoun(ni)),sep(li)),vp(be,obj_be((noun(jan), (adjective(nanpa),adjective(mute)),card((numeral(ale), (numeral(mute),numeral(mute)),numeral(luka),numeral(tu),numeral(wan)))))))),sep(.))
-> s(dec(sim(np(sub(pronoun(ni)),sep(li)),vp(be,obj_be((noun(jan), (adjective(nanpa),adjective(mute),adjective(ale)),card((numeral(mute),numeral(mute),numeral(luka),numeral(tu),numeral(wan)))))))),sep(.))
Error - wrongly passes: sina kepeken ala kepeken e ni ? 
-> s(int(yes_no(np(sub(pronoun(sina))),vp(verb_pre(kepeken),adverb(ala),verb_pre(kepeken),obj_d(sep(e),pronoun(ni))))),sep(?))
Error - wrongly passes: telo pimeja ni li telo loje mi ,  li ale mi . 
-> s(dec(sim(np(sub((noun(telo),adjective(pimeja),pronoun(ni))),sep(li)), (vp(be,obj_be(((adjective(telo),adjective(loje)),pronoun(mi)))),vp(sep(li),vp(be,obj_be((adjective(ale),pronoun(mi)))))))),sep(.))
-> s(dec(sim(np(sub((noun(telo),adjective(pimeja),pronoun(ni))),sep(li)), (vp(be,obj_be(((adjective(telo),adjective(loje)),pronoun(mi)))),vp(sep(li),vp(be,obj_be((card(numeral(ale)),pronoun(mi)))))))),sep(.))
-> s(dec(sim(np(sub((noun(telo),adjective(pimeja),pronoun(ni))),sep(li)), (vp(be,obj_be(((adjective(telo),adjective(loje)),pronoun(mi)))),vp(sep(li),vp(be,obj_be((card(numeral(ale)),pronoun(mi)))))))),sep(.))
-> s(dec(sim(np(sub((noun(telo),adjective(pimeja),pronoun(ni))),sep(li)), (vp(be,obj_be(((adjective(telo),adjective(loje)),pronoun(mi)))),vp(sep(li),vp(be,obj_be((noun(ale),pronoun(mi)))))))),sep(.))
-> s(dec(sim(np(sub((noun(telo),adjective(pimeja),pronoun(ni))),sep(li)), (vp(be,obj_be((noun(telo),adjective(loje),pronoun(mi)))),vp(sep(li),vp(be,obj_be((adjective(ale),pronoun(mi)))))))),sep(.))
-> s(dec(sim(np(sub((noun(telo),adjective(pimeja),pronoun(ni))),sep(li)), (vp(be,obj_be((noun(telo),adjective(loje),pronoun(mi)))),vp(sep(li),vp(be,obj_be((card(numeral(ale)),pronoun(mi)))))))),sep(.))
-> s(dec(sim(np(sub((noun(telo),adjective(pimeja),pronoun(ni))),sep(li)), (vp(be,obj_be((noun(telo),adjective(loje),pronoun(mi)))),vp(sep(li),vp(be,obj_be((card(numeral(ale)),pronoun(mi)))))))),sep(.))
-> s(dec(sim(np(sub((noun(telo),adjective(pimeja),pronoun(ni))),sep(li)), (vp(be,obj_be((noun(telo),adjective(loje),pronoun(mi)))),vp(sep(li),vp(be,obj_be((noun(ale),pronoun(mi)))))))),sep(.))
Error - wrongly passes: mi moku . 
-> s(dec(sim(np(sub(pronoun(mi))),vp(verb_tra(moku)))),sep(.))
-> s(dec(sim(np(sub(pronoun(mi))),vp(be,obj_be(adjective(moku))))),sep(.))
-> s(dec(sim(np(sub(pronoun(mi))),vp(be,obj_be(noun(moku))))),sep(.))</pre>